### PR TITLE
Make produceOperation public

### DIFF
--- a/framework/Operations/Operations/Operation.swift
+++ b/framework/Operations/Operations/Operation.swift
@@ -183,7 +183,7 @@ public class Operation: NSOperation {
         state = .Cancelled
     }
     
-    final func produceOperation(operation: NSOperation) {
+    public final func produceOperation(operation: NSOperation) {
         observers.map { $0.operation(self, didProduceOperation: operation) }
     }
     


### PR DESCRIPTION
Currently, any subclass of `Operation` can't call produceOperation as it's private to `Operation`